### PR TITLE
Minor Fixes

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -72,6 +72,11 @@ header.hidden {
 .logo .name a {
     color: white;
     text-decoration: none;
+    transition: color 0.3s;
+}
+
+.logo .name a:hover {
+    color: #ff6600;
 }
 
 .eportfolio {
@@ -525,7 +530,6 @@ h1 {
 
 .project-text {
     flex: 1; /* Allow text to grow and occupy available space */
-    width: 100%;
     padding: 0 120px;
 }
 
@@ -611,12 +615,13 @@ h1 {
 .section-title {
     text-align: center; /* Center-align the title and line */
     margin-bottom: 20px; /* Add some spacing below the title */
-    margin-top: 50px;
 }
 
 .section-title h2 {
     font-size: 24px; /* Adjust the font size to your preference */
     font-weight: bold; /* Make the title bold */
+    margin-top: 0;
+    padding-top: 24px;
 }
 
 .title-line {

--- a/certificates.html
+++ b/certificates.html
@@ -59,7 +59,7 @@
                     <div id="project1" class="project-details">
                         <div class="project-content">
                             <div class="project-pdf">
-                                <embed src="assets/certificates/UC-4GIX7VM1.pdf" type="application/pdf" height="500px">
+                                <embed src="assets/certificates/UC-4GIX7VM1.pdf" type="application/pdf" height="700px">
                             </div>
                         </div>
 
@@ -76,7 +76,7 @@
                     <div id="project2" class="project-details">
                         <div class="project-content">
                             <div class="project-pdf">
-                                <embed src="assets/certificates/Imagery in Action_Certificate_10312023.pdf" type="application/pdf" height="500px">
+                                <embed src="assets/certificates/Imagery in Action_Certificate_10312023.pdf" type="application/pdf" height="700px">
                             </div>
                         </div>
 
@@ -93,7 +93,7 @@
                     <div id="project3" class="project-details">
                         <div class="project-content">
                             <div class="project-pdf">
-                                <embed src="assets/certificates/Going Places with Spatial Analysis_Certificate_10312021.pdf" type="application/pdf" height="500px">
+                                <embed src="assets/certificates/Going Places with Spatial Analysis_Certificate_10312021.pdf" type="application/pdf" height="700px">
                             </div>
                         </div>
 
@@ -110,7 +110,7 @@
                     <div id="project4" class="project-details">
                         <div class="project-content">
                             <div class="project-pdf">
-                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/ArcGIS Notebooks Basics_Certificate_03092022.pdf" type="application/pdf" height="500px">
+                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/ArcGIS Notebooks Basics_Certificate_03092022.pdf" type="application/pdf" height="700px">
                             </div>
                         </div>
 
@@ -127,7 +127,7 @@
                     <div id="project5" class="project-details">
                         <div class="project-content">
                             <div class="project-pdf">
-                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/Creating Python Scripts for Raster Analysis_Certificate_05042022.pdf" type="application/pdf" height="500px">
+                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/Creating Python Scripts for Raster Analysis_Certificate_05042022.pdf" type="application/pdf" height="700px">
                             </div>
                         </div>
 
@@ -144,7 +144,7 @@
                     <div id="project6" class="project-details">
                         <div class="project-content">
                             <div class="project-pdf">
-                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/Integrating R Scripts into ArcGIS Geoprocessing Tools_Certificate_05102022.pdf" type="application/pdf" height="500px">
+                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/Integrating R Scripts into ArcGIS Geoprocessing Tools_Certificate_05102022.pdf" type="application/pdf" height="700px">
                             </div>
                         </div>
 
@@ -161,7 +161,7 @@
                     <div id="project7" class="project-details">
                         <div class="project-content">
                             <div class="project-pdf">
-                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/Python for Everyone_Certificate_10182021.pdf" type="application/pdf" height="500px">
+                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/Python for Everyone_Certificate_10182021.pdf" type="application/pdf" height="700px">
                             </div>
                         </div>
 
@@ -178,7 +178,7 @@
                     <div id="project8" class="project-details">
                         <div class="project-content">
                             <div class="project-pdf">
-                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/Python Scripting for Geoprocessing Workflows_Certificate_03102022.pdf" type="application/pdf" height="500px">
+                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/Python Scripting for Geoprocessing Workflows_Certificate_03102022.pdf" type="application/pdf" height="700px">
                             </div>
                         </div>
 
@@ -195,7 +195,7 @@
                     <div id="project9" class="project-details">
                         <div class="project-content">
                             <div class="project-pdf">
-                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/Using the R-ArcGIS Bridge_Certificate_05102022.pdf" type="application/pdf" height="500px">
+                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/Using the R-ArcGIS Bridge_Certificate_05102022.pdf" type="application/pdf" height="700px">
                             </div>
                         </div>
 
@@ -212,7 +212,7 @@
                     <div id="project10" class="project-details">
                         <div class="project-content">
                             <div class="project-pdf">
-                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/Visualizing Data Using ArcGIS API for Python_Certificate_05082022.pdf" type="application/pdf" height="500px">
+                                <embed src="assets/certificates/EsriAcad Scripting with Python and R/Visualizing Data Using ArcGIS API for Python_Certificate_05082022.pdf" type="application/pdf" height="700px">
                             </div>
                         </div>
 

--- a/thesis-master.html
+++ b/thesis-master.html
@@ -49,7 +49,7 @@
             </header>
     
         <div class="page-container">
-            <div class="section-title" style="margin-top: 100px;">
+            <div class="section-title" style="margin-top: 150px;">
                 <h2>CONTINUATION OF CONFIDENTIAL PROJECT</h2>
                 <hr class="title-line">
 


### PR DESCRIPTION
### Changes
- Fixed text overflow on the two thesis pages.
- Removed empty whitespace between the project button and its description.
- The logo/header has a hover effect now, making it more obvious it is clickable.
- Increased size of the PDF viewer for certificates from 500px to 700px.
- Fixed header overlap for master thesis on smaller devices.